### PR TITLE
nodemon parameters perceived as tsc-watch parameters, fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "author": "Mochamad Arifin",
   "license": "MIT",
   "scripts": {
-    "dev": "tsc-watch --onFirstSuccess 'nodemon --delay 0.5 -w dist -e js -x node dist/index.js'",
-    "test-watch": "tsc-watch --onFirstSuccess 'nodemon --delay 0.5 -w dist -e js -x node dist/test.js'",
+    "dev": "tsc-watch --onFirstSuccess \"nodemon --delay 0.5 -w dist -e js -x node dist/index.js\"",
+    "test-watch": "tsc-watch --onFirstSuccess \"nodemon --delay 0.5 -w dist -e js -x node dist/test.js\"",
     "clean": "rm -rf dist"
   },
   "dependencies": {


### PR DESCRIPTION
Hi, without this change, I wasn't able to get it to compile on my windows machine + vscode, looks like it is treating the standalone command in the single quotes as a parameterfor the "tsc-watch"

thanks